### PR TITLE
Update requirements to include getkey

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 xlrd
+getkey

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     },
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['xlrd'],
+    install_requires=['xlrd', 'getkey'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Intended Audience :: Developers",


### PR DESCRIPTION
`xls-cli` appears to require the `getkey` package to function. Added this to dependencies in `requirements.txt` and `setup.py`